### PR TITLE
Task/impliment default callback handlers

### DIFF
--- a/src/source/promises.bs
+++ b/src/source/promises.bs
@@ -24,17 +24,17 @@ namespace promises
     end function
 
     ' TODO rename this to `then` once BrighterScript supports using keywords as namespaced function names
-    function onThen(promise as dynamic, callback as function, context = "__INVALID__" as object) as dynamic
+    function onThen(promise as dynamic, callback = promises.internal.identity as function, context = "__INVALID__" as object) as dynamic
         return promises.internal.on("then", promise, callback, context)
     end function
 
     ' TODO rename this to `catch` once BrighterScript supports using keywords as namespaced function names
-    function onCatch(promise as dynamic, callback as function, context = "__INVALID__" as object) as dynamic
+    function onCatch(promise as dynamic, callback = promises.internal.thrower as function, context = "__INVALID__" as object) as dynamic
         return promises.internal.on("catch", promise, callback, context)
     end function
 
     ' TODO rename this to `finally` once BrighterScript supports using keywords as namespaced function names
-    function onFinally(promise as dynamic, callback as function, context = "__INVALID__" as object) as dynamic
+    function onFinally(promise as dynamic, callback = promises.internal.defaultFinally as function, context = "__INVALID__" as object) as dynamic
         return promises.internal.on("finally", promise, callback, context)
     end function
 
@@ -443,17 +443,17 @@ namespace promises
         return {
             _lastPromise: initialPromise
             _context: context
-            then: function(callback as function) as object
+            then: function(callback = promises.internal.identity as function) as object
                 m._lastPromise = promises.onThen(m._lastPromise, callback, m._context)
                 return m
             end function
 
-            "catch": function(callback as function) as object
+            "catch": function(callback = promises.internal.thrower as function) as object
                 m._lastPromise = promises.onCatch(m._lastPromise, callback, m._context)
                 return m
             end function
 
-            finally: function(callback as function) as object
+            finally: function(callback = promises.internal.defaultFinally as function) as object
                 m._lastPromise = promises.onFinally(m._lastPromise, callback, m._context)
                 return m
             end function
@@ -469,6 +469,9 @@ namespace promises
         if promises.isPromise(value) then return value
         return promises.resolve(value)
     end function
+
+    sub noOp(value = invalid, _ = invalid)
+    end sub
 
     enum PromiseState
         pending = "pending"
@@ -736,6 +739,17 @@ namespace promises.internal
                 end if
             end if
         end if
+    end sub
+
+    function identity(value = invalid, _ = invalid) as dynamic
+        return value
+    end function
+
+    function thrower(value = invalid, _ = invalid) as dynamic
+        return promises.reject(value)
+    end function
+
+    sub defaultFinally(_ = invalid)
     end sub
 
     '

--- a/src/source/promises.bs
+++ b/src/source/promises.bs
@@ -24,17 +24,17 @@ namespace promises
     end function
 
     ' TODO rename this to `then` once BrighterScript supports using keywords as namespaced function names
-    function onThen(promise as dynamic, callback = promises.internal.identity as function, context = "__INVALID__" as object) as dynamic
+    function onThen(promise as dynamic, callback = promises.internal.defaultThenCallback as function, context = "__INVALID__" as object) as dynamic
         return promises.internal.on("then", promise, callback, context)
     end function
 
     ' TODO rename this to `catch` once BrighterScript supports using keywords as namespaced function names
-    function onCatch(promise as dynamic, callback = promises.internal.thrower as function, context = "__INVALID__" as object) as dynamic
+    function onCatch(promise as dynamic, callback = promises.internal.defaultCatchCallback as function, context = "__INVALID__" as object) as dynamic
         return promises.internal.on("catch", promise, callback, context)
     end function
 
     ' TODO rename this to `finally` once BrighterScript supports using keywords as namespaced function names
-    function onFinally(promise as dynamic, callback = promises.internal.defaultFinally as function, context = "__INVALID__" as object) as dynamic
+    function onFinally(promise as dynamic, callback = promises.internal.defaultFinallyCallback as function, context = "__INVALID__" as object) as dynamic
         return promises.internal.on("finally", promise, callback, context)
     end function
 
@@ -443,17 +443,17 @@ namespace promises
         return {
             _lastPromise: initialPromise
             _context: context
-            then: function(callback = promises.internal.identity as function) as object
+            then: function(callback = promises.internal.defaultThenCallback as function) as object
                 m._lastPromise = promises.onThen(m._lastPromise, callback, m._context)
                 return m
             end function
 
-            "catch": function(callback = promises.internal.thrower as function) as object
+            "catch": function(callback = promises.internal.defaultCatchCallback as function) as object
                 m._lastPromise = promises.onCatch(m._lastPromise, callback, m._context)
                 return m
             end function
 
-            finally: function(callback = promises.internal.defaultFinally as function) as object
+            finally: function(callback = promises.internal.defaultFinallyCallback as function) as object
                 m._lastPromise = promises.onFinally(m._lastPromise, callback, m._context)
                 return m
             end function
@@ -741,15 +741,15 @@ namespace promises.internal
         end if
     end sub
 
-    function identity(value = invalid, _ = invalid) as dynamic
+    function defaultThenCallback(value = invalid, _ = invalid) as dynamic
         return value
     end function
 
-    function thrower(value = invalid, _ = invalid) as dynamic
+    function defaultCatchCallback(value = invalid, _ = invalid) as dynamic
         return promises.reject(value)
     end function
 
-    sub defaultFinally(_ = invalid)
+    sub defaultFinallyCallback(_ = invalid)
     end sub
 
     '

--- a/src/source/promises.bs
+++ b/src/source/promises.bs
@@ -470,9 +470,6 @@ namespace promises
         return promises.resolve(value)
     end function
 
-    sub noOp(value = invalid, _ = invalid)
-    end sub
-
     enum PromiseState
         pending = "pending"
         resolved = "resolved"

--- a/src/source/promises.spec.bs
+++ b/src/source/promises.spec.bs
@@ -74,6 +74,38 @@ namespace tests
 			end sub, context)
 		end function
 
+		@it("handles default then identify passthrough calls")
+		function _()
+			context = {
+				thenCount: 0
+				catchCount: 0
+				finallyCount: 0
+				result: []
+			}
+
+			results = promises.chain(promises.resolve(1), context).then(function(result, context)
+				context.thenCount++
+				context.result.push(result)
+				return 2
+			end function).then().then().then(function(result, context)
+				context.thenCount++
+				context.result.push(result)
+			end function).catch(sub(error, context)
+				context.catchCount++
+			end sub).finally(sub(context)
+				context.finallyCount++
+			end sub).toPromise()
+
+			return promises.onFinally(results, sub(context)
+				m.testSuite.assertEqual(context, {
+					thenCount: 2
+					catchCount: 0
+					finallyCount: 1
+					result: [1, 2]
+				})
+			end sub, context)
+		end function
+
 		@it("calls thens in order")
 		function _()
 			context = {
@@ -155,6 +187,38 @@ namespace tests
 			end sub, context)
 		end function
 
+		@it("handles default then thrower passthrough calls")
+		function _()
+			context = {
+				thenCount: 0
+				catchCount: 0
+				finallyCount: 0
+				result: []
+			}
+
+			results = promises.chain(promises.reject(1), context).then(function(result, context)
+				context.thenCount++
+				context.result.push(invalid)
+			end function).catch(function(result, context)
+				context.catchCount++
+				context.result.push(result)
+				return promises.reject(2)
+			end function).catch().catch().catch(function(result, context)
+				context.catchCount++
+				context.result.push(result)
+			end function).finally(sub(context)
+				context.finallyCount++
+			end sub).toPromise()
+
+			return promises.onFinally(results, sub(context)
+				m.testSuite.assertEqual(context, {
+					thenCount: 0
+					catchCount: 2
+					finallyCount: 1
+					result: [1, 2]
+				})
+			end sub, context)
+		end function
 
 		@it("calls finally in order")
 		function _()
@@ -197,6 +261,48 @@ namespace tests
 					thenCount: 4
 					catchCount: 0
 					finallyCount: 4
+					result: [1, 2, 3, 4]
+				})
+			end sub, context)
+		end function
+
+		@it("handles default finally passthrough calls")
+		function _()
+			context = {
+				thenCount: 0
+				catchCount: 0
+				finallyCount: 0
+				result: []
+			}
+
+			results = promises.chain(promises.resolve(1), context).then(function(result, context)
+				context.thenCount++
+				context.result.push(result)
+				return 2
+			end function).then(function(result, context)
+				context.thenCount++
+				context.result.push(result)
+				return 3
+			end function).then(function(result, context)
+				context.thenCount++
+				context.result.push(result)
+				return 4
+			end function).then(function(result, context)
+				context.thenCount++
+				context.result.push(result)
+			end function).catch(sub(error, context)
+				context.catchCount++
+			end sub).finally(function(context)
+				context.finallyCount++
+			end function).finally().finally().finally(function(context)
+				context.finallyCount++
+			end function).toPromise()
+
+			return promises.onFinally(results, sub(context)
+				m.testSuite.assertEqual(context, {
+					thenCount: 4
+					catchCount: 0
+					finallyCount: 2
 					result: [1, 2, 3, 4]
 				})
 			end sub, context)
@@ -1184,6 +1290,15 @@ namespace tests
 		end sub
 
 		@async
+		@it("handles empty callbacks")
+		sub _()
+			promises.onThen(promises.onThen(promises.resolve("resolved")), sub(value)
+				m.testSuite.assertEqual(value, "resolved")
+				m.testSuite.done()
+			end sub)
+		end sub
+
+		@async
 		@it("does not response to rejected promises")
 		sub _()
 			context = { thenCount: 0 }
@@ -1206,6 +1321,15 @@ namespace tests
 		@it("catches rejected promises")
 		sub _()
 			promises.onCatch(promises.reject("rejected"), sub(value)
+				m.testSuite.assertEqual(value, "rejected")
+				m.testSuite.done()
+			end sub)
+		end sub
+
+		@async
+		@it("handles empty callbacks")
+		sub _()
+			promises.onCatch(promises.onCatch(promises.reject("rejected")), sub(value)
 				m.testSuite.assertEqual(value, "rejected")
 				m.testSuite.done()
 			end sub)
@@ -1243,9 +1367,33 @@ namespace tests
 		end sub
 
 		@async
+		@it("handles resolved promise with empty callback")
+		sub _()
+			promise = promises.onFinally(promises.onFinally(promises.resolve("resolved")), sub()
+			end sub)
+
+			promises.onThen(promise, sub(value)
+				m.testSuite.assertEqual(value, "resolved")
+				m.testSuite.done()
+			end sub)
+		end sub
+
+		@async
 		@it("handles rejected promise")
 		sub _()
 			promise = promises.onFinally(promises.reject("rejected"), sub()
+			end sub)
+
+			promises.onCatch(promise, sub(value)
+				m.testSuite.assertEqual(value, "rejected")
+				m.testSuite.done()
+			end sub)
+		end sub
+
+		@async
+		@it("handles rejected promise with empty callback")
+		sub _()
+			promise = promises.onFinally(promises.onFinally(promises.reject("rejected")), sub()
 			end sub)
 
 			promises.onCatch(promise, sub(value)


### PR DESCRIPTION
Support calling `.then()`, `.catch()`, `.finally()` (and their on* counterparts) without any callbacks, which result in passthrough code. See [this article](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/then) for how it works in javascript, we are mimicking that same behavior. 

For example:
```
'this .then and .catch are essentially noops that behave like they weren't defined in the first place.
promises.chain(somePromise).then().catch()
