### PR TITLE
Reduce data cloning

### DIFF
--- a/src/source/promises.bs
+++ b/src/source/promises.bs
@@ -448,6 +448,14 @@ namespace promises
         return promise.hasField(promises.internal.PromiseField.promiseState)
     end function
 
+    ' Determines if the given node event was triggered on a promise like node.
+    function isPromiseEvent(event as dynamic) as boolean
+        if not type(event) = "roSGNodeEvent" then
+            return false
+        end if
+        return lCase(event.getField()) = promises.internal.PromiseField.promiseStateLowerCase
+    end function
+
     ' Remove all promise storage from the current m
     sub clean()
         for each key in m
@@ -530,6 +538,8 @@ namespace promises.internal
     enum PromiseField
         promiseState = "promiseState"
         promiseResult = "promiseResult"
+        promiseStateLowerCase = "promisestate"
+        promiseResultLowerCase = "promiseresult"
     end enum
 
     ' Clear storage for a given promise

--- a/src/source/promises.bs
+++ b/src/source/promises.bs
@@ -533,8 +533,13 @@ namespace promises.internal
     end enum
 
     ' Clear storage for a given promise
-    sub clearPromiseStorage(promise as object)
-        m.delete("__promises__" + promise.id)
+    sub clearPromiseStorage(promise as object, nodeEvent = invalid as dynamic)
+        if nodeEvent <> invalid then
+            id = "__promises__" + nodeEvent.getNode()
+        else
+            id = "__promises__" + promise.id
+        end if
+        m.delete(id)
     end sub
 
     function getLibPath() as string
@@ -552,10 +557,16 @@ namespace promises.internal
     end function
 
     ' Get the storage for a promise on `m`
-    function getPromiseStorage(promise as object) as object
-        id = "__promises__" + promise.id
+    function getPromiseStorage(promise as object, nodeEvent = invalid as dynamic) as object
+        if nodeEvent <> invalid then
+            id = "__promises__" + nodeEvent.getNode()
+        else
+            id = "__promises__" + promise.id
+        end if
 
         storage = m[id]
+
+        ' Only create storage and register observers if it does not exist
         if storage = invalid then
             ' unregister any observers on the promise to prevent multiple callbacks
             promises.internal.unobserveFieldScoped(promise, promises.internal.PromiseField.promiseState)
@@ -564,7 +575,7 @@ namespace promises.internal
                 promises.internal.delay(sub(context as dynamic)
                     promises.internal.notifyListeners(context.event)
                 end sub, { event: event })
-            end sub)
+            end sub, [promises.internal.PromiseField.promiseResult])
 
             storage = {
                 promise: promise
@@ -574,6 +585,7 @@ namespace promises.internal
             }
             m[id] = storage
         end if
+
         return storage
     end function
 
@@ -634,29 +646,29 @@ namespace promises.internal
 
             ' unregister any observers once the promise is completed
             promises.internal.unobserveFieldScoped(originalPromise, promises.internal.PromiseField.promiseState)
-            promiseStorage = promises.internal.getPromiseStorage(originalPromise)
+            promiseStorage = promises.internal.getPromiseStorage(originalPromise, event)
             ' Delete the storage for this promise since we are going to handled all of the current listeners.
             ' Any new listeners created as a result of the logic in the callbacks will
             ' register a new instance of the promise storage item. If a new storage item is created
             ' we will notify the new listeners when we are done with the current ones.
-            promises.internal.clearPromiseStorage(originalPromise)
+            promises.internal.clearPromiseStorage(originalPromise, event)
 
-            promiseState = originalPromise.promiseState
-            promiseResult = originalPromise.promiseResult
+            promiseState = event.getData()
+            promiseResult = event.getInfo().promiseResult
 
             'handle .then() listeners
             for each listener in promiseStorage.thenListeners
-                promises.internal.processPromiseListener(originalPromise, listener, promiseState = promises.PromiseState.resolved, promiseResult)
+                promises.internal.processPromiseListener(originalPromise, promiseState, listener, promiseState = promises.PromiseState.resolved, promiseResult)
             end for
 
             'handle .catch() listeners
             for each listener in promiseStorage.catchListeners
-                promises.internal.processPromiseListener(originalPromise, listener, promiseState = promises.PromiseState.rejected, promiseResult)
+                promises.internal.processPromiseListener(originalPromise, promiseState, listener, promiseState = promises.PromiseState.rejected, promiseResult)
             end for
 
             'handle .finally() listeners
             for each listener in promiseStorage.finallyListeners
-                promises.internal.processPromiseListener(originalPromise, listener, true)
+                promises.internal.processPromiseListener(originalPromise, promiseState, listener, true)
             end for
             #if PROMISES_DEBUG
                 if m.__promises__debug = invalid then
@@ -694,7 +706,7 @@ namespace promises.internal
     end function
 
     ' Handle an individual promise listener
-    sub processPromiseListener(originalPromise as object, storageItem as object, callCallback as boolean, promiseValue = "__INVALID__" as dynamic)
+    sub processPromiseListener(originalPromise as object, originalPromiseState as string, storageItem as object, callCallback as boolean, promiseValue = "__INVALID__" as dynamic)
         newPromise = storageItem.promise
         #if PROMISES_DEBUG
             print "[promises.notify]", originalPromise.id, "notifying", newPromise.id
@@ -769,7 +781,7 @@ namespace promises.internal
             end try
         else
             'use the current promise value to pass to the next promise (this is a .catch handler)
-            if originalPromise.promiseState = promises.PromiseState.rejected then
+            if originalPromiseState = promises.PromiseState.rejected then
                 callbackResult = promises.reject(promiseValue)
             else
                 callbackResult = promiseValue
@@ -811,10 +823,11 @@ namespace promises.internal
                 context = {
                     newPromise: newPromise
                     originalPromise: originalPromise
+                    originalPromiseState: originalPromiseState
                 }
 
                 promises.onThen(callbackPromise, sub (result as dynamic, context as dynamic)
-                    if context.originalPromise.promiseState = promises.PromiseState.resolved then
+                    if context.originalPromiseState = promises.PromiseState.resolved then
                         promises.resolve(context.originalPromise.promiseResult, context.newPromise)
                     else
                         promises.reject(context.originalPromise.promiseResult, context.newPromise)
@@ -825,7 +838,7 @@ namespace promises.internal
                     promises.reject(error, context.newPromise)
                 end sub, context)
             else
-                if originalPromise.promiseState = promises.PromiseState.resolved then
+                if originalPromiseState = promises.PromiseState.resolved then
                     promises.resolve(originalPromise.promiseResult, newPromise)
                 else
                     promises.reject(originalPromise.promiseResult, newPromise)

--- a/src/source/promises.bs
+++ b/src/source/promises.bs
@@ -658,17 +658,17 @@ namespace promises.internal
 
             'handle .then() listeners
             for each listener in promiseStorage.thenListeners
-                promises.internal.processPromiseListener(originalPromise, promiseState, listener, promiseState = promises.PromiseState.resolved, promiseResult)
+                promises.internal.processPromiseListener(originalPromise, promiseState, listener, promiseState = promises.PromiseState.resolved, true, promiseResult)
             end for
 
             'handle .catch() listeners
             for each listener in promiseStorage.catchListeners
-                promises.internal.processPromiseListener(originalPromise, promiseState, listener, promiseState = promises.PromiseState.rejected, promiseResult)
+                promises.internal.processPromiseListener(originalPromise, promiseState, listener, promiseState = promises.PromiseState.rejected, true, promiseResult)
             end for
 
             'handle .finally() listeners
             for each listener in promiseStorage.finallyListeners
-                promises.internal.processPromiseListener(originalPromise, promiseState, listener, true)
+                promises.internal.processPromiseListener(originalPromise, promiseState, listener, true, false, promiseResult)
             end for
             #if PROMISES_DEBUG
                 if m.__promises__debug = invalid then
@@ -706,7 +706,7 @@ namespace promises.internal
     end function
 
     ' Handle an individual promise listener
-    sub processPromiseListener(originalPromise as object, originalPromiseState as string, storageItem as object, callCallback as boolean, promiseValue = "__INVALID__" as dynamic)
+    sub processPromiseListener(originalPromise as object, originalPromiseState as string, storageItem as object, callCallback as boolean, isThenOrCatch as boolean, promiseValue = invalid as dynamic)
         newPromise = storageItem.promise
         #if PROMISES_DEBUG
             print "[promises.notify]", originalPromise.id, "notifying", newPromise.id
@@ -714,7 +714,6 @@ namespace promises.internal
         callback = storageItem.callback
         context = storageItem.context
         hasContext = promises.internal.isSet(context)
-        isThenOrCatch = promises.internal.isSet(promiseValue)
         'only call the callback if configured to do so
         if callCallback then
             #if PROMISES_DEBUG
@@ -824,13 +823,14 @@ namespace promises.internal
                     newPromise: newPromise
                     originalPromise: originalPromise
                     originalPromiseState: originalPromiseState
+                    originalPromiseResult: promiseValue
                 }
 
                 promises.onThen(callbackPromise, sub (result as dynamic, context as dynamic)
                     if context.originalPromiseState = promises.PromiseState.resolved then
-                        promises.resolve(context.originalPromise.promiseResult, context.newPromise)
+                        promises.resolve(context.originalPromiseResult, context.newPromise)
                     else
-                        promises.reject(context.originalPromise.promiseResult, context.newPromise)
+                        promises.reject(context.originalPromiseResult, context.newPromise)
                     end if
                 end sub, context)
 
@@ -839,9 +839,9 @@ namespace promises.internal
                 end sub, context)
             else
                 if originalPromiseState = promises.PromiseState.resolved then
-                    promises.resolve(originalPromise.promiseResult, newPromise)
+                    promises.resolve(promiseValue, newPromise)
                 else
-                    promises.reject(originalPromise.promiseResult, newPromise)
+                    promises.reject(promiseValue, newPromise)
                 end if
             end if
         end if


### PR DESCRIPTION
- Use `infoFields` to reduce data cloning and rendezvous when handling promise callbacks.
- pass `promiseState` and `promiseResult` into child functions to reduce cloning and rendezvous
- add `isPromiseEvent` for future use when task support is added (#67)
- get the promise ID from the nodeEvent when applicable in promise storage functions, which reduces cloning and rendezvous
- remove the `"__INVALID"` parameter value in favor of passing a boolean from the call site

