### PR TITLE
Remove @only() from async test cases

### DIFF
--- a/src/source/promises.spec.bs
+++ b/src/source/promises.spec.bs
@@ -1290,7 +1290,6 @@ namespace tests
         end sub
 
         @async
-        @only()
         @it("recovers when did NOT send context, but DID define the parameter (testing multiple param types")
         sub _()
             getGlobalAA().myCount = 0
@@ -1370,7 +1369,6 @@ namespace tests
         end sub
 
         @async
-        @only()
         @it("recovers when did NOT send context, but DID define the parameter (testing multiple param types")
         sub _()
             getGlobalAA().myCount = 0
@@ -1454,7 +1452,6 @@ namespace tests
         end sub
 
         @async
-        @only()
         @it("recovers when did NOT send context, but DID define the parameter (testing multiple param types")
         sub _()
             getGlobalAA().myCount = 0


### PR DESCRIPTION
Removed @only() decorator from multiple test cases.