### PR TITLE
Bump ropm to ^0.11.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "fs-extra": "^11.1.1",
         "roku-deploy": "^3.17.4",
         "rooibos-roku": "^5.15.7",
-        "ropm": "^0.11.5",
+        "ropm": "^0.11.7",
         "semver": "^7.7.2",
         "ts-node": "^10.9.1",
         "typescript": "^5.2.2"
@@ -551,26 +551,6 @@
       "resolved": "https://registry.npmjs.org/@vscode/debugprotocol/-/debugprotocol-1.68.0.tgz",
       "integrity": "sha512-2J27dysaXmvnfuhFGhfeuxfHRXunqNPxtBoR3koiTOA9rdxWNDTa1zIFLCFMSHJ9MPTPKFcBeblsyaCJCIlQxg==",
       "dev": true
-    },
-    "node_modules/@xml-tools/ast": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@xml-tools/ast/-/ast-5.0.5.tgz",
-      "integrity": "sha512-avvzTOvGplCx9JSKdsTe3vK+ACvsHy2HxVfkcfIqPzu+kF5CT4rw5aUVzs0tJF4cnDyMRVkSyVxR07X0Px8gPA==",
-      "dev": true,
-      "dependencies": {
-        "@xml-tools/common": "^0.1.6",
-        "@xml-tools/parser": "^1.0.11",
-        "lodash": "4.17.21"
-      }
-    },
-    "node_modules/@xml-tools/common": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@xml-tools/common/-/common-0.1.6.tgz",
-      "integrity": "sha512-7aVZeEYccs1KI/Asd6KKnrB4dTAWXTkjRMjG40ApGEUp5NpfQIvWLEBvMv85Koj2lbSpagcAERwDy9qMsfWGdA==",
-      "dev": true,
-      "dependencies": {
-        "lodash": "4.17.21"
-      }
     },
     "node_modules/@xml-tools/parser": {
       "version": "1.0.11",
@@ -3062,21 +3042,21 @@
       }
     },
     "node_modules/ropm": {
-      "version": "0.11.6",
-      "resolved": "https://registry.npmjs.org/ropm/-/ropm-0.11.6.tgz",
-      "integrity": "sha512-4xVAAIGRsf3OqeJ/nTtvC3wqnyIf/lnluLQ0syEhBqdsQuikLhqstL/gi9e/86f/oORc5isoRC+/huvqtOoDWQ==",
+      "version": "0.11.7",
+      "resolved": "https://registry.npmjs.org/ropm/-/ropm-0.11.7.tgz",
+      "integrity": "sha512-J+gazn70Dj87Jr4sqwmclwCA+baQSr7VstZL+ypDBl6IIOcpZEF8Ejtdc2XmuyUsDXbbQnlWUUl8rnqEkgmWow==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@rokucommunity/logger": "^0.3.11",
-        "@xml-tools/ast": "^5.0.5",
+        "@rokucommunity/logger": "^0.3.12",
         "@xml-tools/parser": "1.0.10",
-        "brighterscript": "^0.72.1",
+        "brighterscript": "^0.72.2",
         "del": "6.0.0",
         "fs-extra": "9.1.0",
         "glob-all": "3.2.1",
         "latinize": "0.5.0",
         "npm-packlist": "2.1.4",
-        "roku-deploy": "^3.17.2",
+        "roku-deploy": "^3.17.4",
         "semver": "^7.6.3",
         "yargs": "16.2.0"
       },
@@ -4350,26 +4330,6 @@
       "resolved": "https://registry.npmjs.org/@vscode/debugprotocol/-/debugprotocol-1.68.0.tgz",
       "integrity": "sha512-2J27dysaXmvnfuhFGhfeuxfHRXunqNPxtBoR3koiTOA9rdxWNDTa1zIFLCFMSHJ9MPTPKFcBeblsyaCJCIlQxg==",
       "dev": true
-    },
-    "@xml-tools/ast": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@xml-tools/ast/-/ast-5.0.5.tgz",
-      "integrity": "sha512-avvzTOvGplCx9JSKdsTe3vK+ACvsHy2HxVfkcfIqPzu+kF5CT4rw5aUVzs0tJF4cnDyMRVkSyVxR07X0Px8gPA==",
-      "dev": true,
-      "requires": {
-        "@xml-tools/common": "^0.1.6",
-        "@xml-tools/parser": "^1.0.11",
-        "lodash": "^4.18.1"
-      }
-    },
-    "@xml-tools/common": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@xml-tools/common/-/common-0.1.6.tgz",
-      "integrity": "sha512-7aVZeEYccs1KI/Asd6KKnrB4dTAWXTkjRMjG40ApGEUp5NpfQIvWLEBvMv85Koj2lbSpagcAERwDy9qMsfWGdA==",
-      "dev": true,
-      "requires": {
-        "lodash": "^4.18.1"
-      }
     },
     "@xml-tools/parser": {
       "version": "1.0.11",
@@ -6210,7 +6170,7 @@
         "is-glob": "^4.0.3",
         "jsonc-parser": "^2.3.0",
         "jszip": "^3.6.0",
-        "lodash": "^4.18.1",
+        "lodash": "^4.17.21",
         "micromatch": "^4.0.4",
         "moment": "^2.29.1",
         "parse-ms": "^2.1.0",
@@ -6332,21 +6292,20 @@
       }
     },
     "ropm": {
-      "version": "0.11.6",
-      "resolved": "https://registry.npmjs.org/ropm/-/ropm-0.11.6.tgz",
-      "integrity": "sha512-4xVAAIGRsf3OqeJ/nTtvC3wqnyIf/lnluLQ0syEhBqdsQuikLhqstL/gi9e/86f/oORc5isoRC+/huvqtOoDWQ==",
+      "version": "0.11.7",
+      "resolved": "https://registry.npmjs.org/ropm/-/ropm-0.11.7.tgz",
+      "integrity": "sha512-J+gazn70Dj87Jr4sqwmclwCA+baQSr7VstZL+ypDBl6IIOcpZEF8Ejtdc2XmuyUsDXbbQnlWUUl8rnqEkgmWow==",
       "dev": true,
       "requires": {
-        "@rokucommunity/logger": "^0.3.11",
-        "@xml-tools/ast": "^5.0.5",
+        "@rokucommunity/logger": "^0.3.12",
         "@xml-tools/parser": "1.0.10",
-        "brighterscript": "^0.72.1",
+        "brighterscript": "^0.72.2",
         "del": "6.0.0",
         "fs-extra": "9.1.0",
         "glob-all": "3.2.1",
         "latinize": "0.5.0",
         "npm-packlist": "2.1.4",
-        "roku-deploy": "^3.17.2",
+        "roku-deploy": "^3.17.4",
         "semver": "^7.6.3",
         "yargs": "16.2.0"
       },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "audit": "npm audit"
   },
   "overrides": {
-    "lodash": "^4.18.1",
     "serialize-javascript": "^7.0.5"
   },
   "devDependencies": {
@@ -27,7 +26,7 @@
     "fs-extra": "^11.1.1",
     "roku-deploy": "^3.17.4",
     "rooibos-roku": "^5.15.7",
-    "ropm": "^0.11.5",
+    "ropm": "^0.11.7",
     "semver": "^7.7.2",
     "ts-node": "^10.9.1",
     "typescript": "^5.2.2"


### PR DESCRIPTION
## Summary
- Bumps `ropm` ^0.11.5 → ^0.11.7. The new release dropped `@xml-tools/ast`/`@xml-tools/common` (which transitively pulled the vulnerable lodash) in favor of `@xml-tools/parser` alone.
- Removes the `lodash: ^4.18.1` override added in #76 — no longer needed now that nothing in the tree depends on lodash.
- Keeps the `serialize-javascript ^7.0.5` override.